### PR TITLE
Amend git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is an AI Agent built using Composio and Vercel, it is a personal assistant 
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/composio-ai/executive-assistant.git
+git clone https://github.com/ComposioHQ/Executive-Assistant.git
 cd Executive-Assistant
 ```
 


### PR DESCRIPTION
Was getting an error for the original command, and realised it wasn't correct. 

```
git clone https://github.com/composio-ai/executive-assistant.git

Cloning into 'executive-assistant'...
remote: Repository not found.
fatal: repository 'https://github.com/composio-ai/executive-assistant.git/' not found
```